### PR TITLE
Add Stockfish variant options

### DIFF
--- a/uci.go
+++ b/uci.go
@@ -219,13 +219,13 @@ func (eng *Engine) NewGame(opts NewGameOpts) {
 	} else {
 		eng.StartPos = "position fen " + opts.InitialFen + " moves "
 	}
-	eng.send(eng.StartPos + opts.Moves)
+	eng.Position(opts.Moves)
 	eng.Side = opts.Side
 }
 
 // Set the position of the game after the initial start position. Algrebriac notiation, e.g `e2e4 e7e6`
-func (eng *Engine) Position(pos string) {
-	eng.send(eng.StartPos + pos)
+func (eng *Engine) Position(moves string) {
+	eng.send(eng.StartPos + moves)
 }
 
 func addOpt(name string, value int) string {

--- a/uci.go
+++ b/uci.go
@@ -36,6 +36,9 @@ type Option struct {
 
 // Options for creating a new game
 type NewGameOpts struct {
+	Variant struct {
+		Key string
+	}
 	StartPos string // Start position of the game in FEN format. Default is `startpos`
 	Side     int    // Which side should the Engine play as. Must be uci.W or uci.B
 }
@@ -157,6 +160,7 @@ func (eng *Engine) SetOption(name string, value interface{}) bool {
 					v = "false"
 				}
 			}
+			log.Println("setoption name " + name + " value " + v)
 			eng.send("setoption name " + name + " value " + v)
 			return true
 		}
@@ -195,6 +199,11 @@ func (eng *Engine) receive(stopPrefix string) (lines []string) {
 
 // Start a new game. Only one game should be played at a time
 func (eng *Engine) NewGame(opts NewGameOpts) {
+	if opts.Variant.Key == "chess960" {
+		eng.SetOption("UCI_Chess960", "true")
+	} else {
+		eng.SetOption("UCI_Chess960", "false")
+	}
 	if opts.StartPos == "" || opts.StartPos == "startpos" {
 		eng.StartPos = "position startpos moves "
 	} else {

--- a/uci.go
+++ b/uci.go
@@ -40,14 +40,7 @@ type NewGameOpts struct {
 		Key string
 	}
 	InitialFen string
-	State struct {
-		Type  string
-		Moves string
-		Wtime int
-		Btime int
-		Winc  int
-		Binc  int
-	}
+	Moves string
 	Side     int    // Which side should the Engine play as. Must be uci.W or uci.B
 }
 
@@ -226,7 +219,7 @@ func (eng *Engine) NewGame(opts NewGameOpts) {
 	} else {
 		eng.StartPos = "position fen " + opts.InitialFen + " moves "
 	}
-	eng.send(eng.StartPos + opts.State.Moves)
+	eng.send(eng.StartPos + opts.Moves)
 	eng.Side = opts.Side
 }
 


### PR DESCRIPTION
Per the specification at https://www.shredderchess.com/download.html : 

> UCI could easily be extended to support Chess960 (also known as Fischer Random Chess).
>
> The engine has to tell the GUI that it is capable of playing Chess960 and the GUI has to tell the engine that is should play according to the Chess960 rules.
> This is done by the special engine option UCI_Chess960. If the engine knows about Chess960 it should send the command
> 'option name UCI_Chess960 type check default false'
> to the GUI at program startup.
> Whenever a Chess960 game is played, the GUI should set this engine option to 'true'.

but also I added all other Stockfish-supported Lichess variants.