### PR TITLE
Clamp out-of-range integer values

### DIFF
--- a/uci.go
+++ b/uci.go
@@ -152,6 +152,11 @@ func (eng *Engine) SetOption(name string, value interface{}) bool {
 				v, _ = value.(string)
 			case int:
 				vv, _ := value.(int)
+				if (vv < option.Min) {
+					vv = option.Min
+				} else if (vv > option.Max) {
+					vv = option.Max
+				}
 				v = strconv.Itoa(vv)
 			case bool:
 				vv, _ := value.(bool)


### PR DESCRIPTION
I have an experimental fork of lichess-bot which sets Stockfish contempt to the difference between player ratings, although that difference is sometimes outside range [-100, 100].

Perhaps it would be better to return an error if an integer value is out-of-range, I don't know.